### PR TITLE
Refactor QueryBestBlock() to only return the `uint64` block height 

### DIFF
--- a/clientcontroller/babylon_consumer.go
+++ b/clientcontroller/babylon_consumer.go
@@ -232,14 +232,15 @@ func (bc *BabylonConsumerController) QueryActivatedHeight() (uint64, error) {
 	return res.Height, nil
 }
 
-func (bc *BabylonConsumerController) QueryBestBlock() (*types.BlockInfo, error) {
+func (bc *BabylonConsumerController) QueryLatestBlockHeight() (uint64, error) {
 	blocks, err := bc.queryLatestBlocks(nil, 1, finalitytypes.QueriedBlockStatus_ANY, true)
 	if err != nil || len(blocks) != 1 {
 		// try query comet block if the index block query is not available
-		return bc.queryCometBestBlock()
+		block, err := bc.queryCometBestBlock()
+		return block.Height, err
 	}
 
-	return blocks[0], nil
+	return blocks[0].Height, nil
 }
 
 func (bc *BabylonConsumerController) queryCometBestBlock() (*types.BlockInfo, error) {

--- a/clientcontroller/evm_consumer.go
+++ b/clientcontroller/evm_consumer.go
@@ -127,15 +127,12 @@ func (ec *EVMConsumerController) QueryActivatedHeight() (uint64, error) {
 	return 0, nil
 }
 
-func (ec *EVMConsumerController) QueryBestBlock() (*types.BlockInfo, error) {
+func (ec *EVMConsumerController) QueryLatestBlockHeight() (uint64, error) {
 	/* TODO: implement
 	get the latest L2 block number from a RPC call
 	*/
 
-	return &types.BlockInfo{
-		Height: uint64(0),
-		Hash:   nil,
-	}, nil
+	return uint64(0), nil
 }
 
 func (ec *EVMConsumerController) Close() error {

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -71,8 +71,8 @@ type ConsumerController interface {
 	// QueryBlocks returns a list of blocks from startHeight to endHeight
 	QueryBlocks(startHeight, endHeight, limit uint64) ([]*types.BlockInfo, error)
 
-	// QueryBestBlock queries the tip block of the consumer chain
-	QueryBestBlock() (*types.BlockInfo, error)
+	// QueryBestBlock queries the tip block height of the consumer chain
+	QueryLatestBlockHeight() (uint64, error)
 
 	// QueryActivatedHeight returns the activated height of the consumer chain
 	// error will be returned if the consumer chain has not been activated

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -231,7 +231,7 @@ func (app *FinalityProviderApp) getFpPrivKey(fpPk []byte) (*btcec.PrivateKey, er
 
 // SyncFinalityProviderStatus syncs the status of the finality-providers
 func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
-	latestBlock, err := app.consumerCon.QueryBestBlock()
+	latestBlockHeight, err := app.consumerCon.QueryLatestBlockHeight()
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 	}
 
 	for _, fp := range fps {
-		vp, err := app.consumerCon.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlock.Height)
+		vp, err := app.consumerCon.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlockHeight)
 		if err != nil {
 			// if error occured then the finality-provider is not registered in the Babylon chain yet
 			continue

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -125,14 +125,14 @@ func (cp *ChainPoller) GetBlockInfoChan() <-chan *types.BlockInfo {
 	return cp.blockInfoChan
 }
 
-func (cp *ChainPoller) latestBlockWithRetry() (*types.BlockInfo, error) {
+func (cp *ChainPoller) latestBlockHeightWithRetry() (uint64, error) {
 	var (
-		latestBlock *types.BlockInfo
-		err         error
+		latestBlockHeight uint64
+		err               error
 	)
 
 	if err := retry.Do(func() error {
-		latestBlock, err = cp.consumerCon.QueryBestBlock()
+		latestBlockHeight, err = cp.consumerCon.QueryLatestBlockHeight()
 		if err != nil {
 			return err
 		}
@@ -145,9 +145,9 @@ func (cp *ChainPoller) latestBlockWithRetry() (*types.BlockInfo, error) {
 			zap.Error(err),
 		)
 	})); err != nil {
-		return nil, err
+		return 0, err
 	}
-	return latestBlock, nil
+	return latestBlockHeight, nil
 }
 
 func (cp *ChainPoller) blockWithRetry(height uint64) (*types.BlockInfo, error) {
@@ -186,13 +186,13 @@ func (cp *ChainPoller) validateStartHeight(startHeight uint64) error {
 
 	var currentBestChainHeight uint64
 	for {
-		lastestBlock, err := cp.latestBlockWithRetry()
+		lastestBlockHeight, err := cp.latestBlockHeightWithRetry()
 		if err != nil {
 			cp.logger.Debug("failed to query babylon for the latest status", zap.Error(err))
 			continue
 		}
 
-		currentBestChainHeight = lastestBlock.Height
+		currentBestChainHeight = lastestBlockHeight
 		break
 	}
 

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -35,10 +35,7 @@ func FuzzChainPoller_Start(f *testing.F) {
 		mockConsumerController := mocks.NewMockConsumerController(ctl)
 		mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 
-		currentBlockRes := &types.BlockInfo{
-			Height: currentHeight,
-		}
-		mockConsumerController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 
 		for i := startHeight; i <= endHeight; i++ {
 			resBlock := &types.BlockInfo{
@@ -86,11 +83,7 @@ func FuzzChainPoller_SkipHeight(f *testing.F) {
 		mockConsumerController := mocks.NewMockConsumerController(ctl)
 		mockBabylonController.EXPECT().Close().Return(nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
-
-		currentBlockRes := &types.BlockInfo{
-			Height: currentHeight,
-		}
-		mockConsumerController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 
 		for i := startHeight; i <= skipHeight; i++ {
 			resBlock := &types.BlockInfo{

--- a/finality-provider/service/fp_manager.go
+++ b/finality-provider/service/fp_manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/babylonchain/finality-provider/finality-provider/proto"
 	"github.com/babylonchain/finality-provider/finality-provider/store"
 	"github.com/babylonchain/finality-provider/metrics"
-	"github.com/babylonchain/finality-provider/types"
 )
 
 const instanceTerminatingMsg = "terminating the finality-provider instance due to critical error"
@@ -134,7 +133,7 @@ func (fpm *FinalityProviderManager) monitorStatusUpdate() {
 	for {
 		select {
 		case <-statusUpdateTicker.C:
-			latestBlock, err := fpm.getLatestBlockWithRetry()
+			latestBlockHeight, err := fpm.getLatestBlockHeightWithRetry()
 			if err != nil {
 				fpm.logger.Debug("failed to get the latest block", zap.Error(err))
 				continue
@@ -142,12 +141,12 @@ func (fpm *FinalityProviderManager) monitorStatusUpdate() {
 			fpis := fpm.ListFinalityProviderInstances()
 			for _, fpi := range fpis {
 				oldStatus := fpi.GetStatus()
-				power, err := fpi.GetVotingPowerWithRetry(latestBlock.Height)
+				power, err := fpi.GetVotingPowerWithRetry(latestBlockHeight)
 				if err != nil {
 					fpm.logger.Debug(
 						"failed to get the voting power",
 						zap.String("fp_btc_pk", fpi.GetBtcPkHex()),
-						zap.Uint64("height", latestBlock.Height),
+						zap.Uint64("height", latestBlockHeight),
 						zap.Error(err),
 					)
 					continue
@@ -407,14 +406,14 @@ func (fpm *FinalityProviderManager) addFinalityProviderInstance(
 	return nil
 }
 
-func (fpm *FinalityProviderManager) getLatestBlockWithRetry() (*types.BlockInfo, error) {
+func (fpm *FinalityProviderManager) getLatestBlockHeightWithRetry() (uint64, error) {
 	var (
-		latestBlock *types.BlockInfo
-		err         error
+		latestBlockHeight uint64
+		err               error
 	)
 
 	if err := retry.Do(func() error {
-		latestBlock, err = fpm.consumerCon.QueryBestBlock()
+		latestBlockHeight, err = fpm.consumerCon.QueryLatestBlockHeight()
 		if err != nil {
 			return err
 		}
@@ -427,8 +426,8 @@ func (fpm *FinalityProviderManager) getLatestBlockWithRetry() (*types.BlockInfo,
 			zap.Error(err),
 		)
 	})); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return latestBlock, nil
+	return latestBlockHeight, nil
 }

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -54,7 +54,7 @@ func FuzzStatusUpdate(f *testing.F) {
 		}
 		mockConsumerController.EXPECT().Close().Return(nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryLatestFinalizedBlocks(gomock.Any()).Return(nil, nil).AnyTimes()
-		mockConsumerController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
+		mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 		mockConsumerController.EXPECT().QueryBlock(gomock.Any()).Return(currentBlockRes, nil).AnyTimes()
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -181,8 +181,7 @@ func TestFastSync(t *testing.T) {
 	t.Logf("the latest finalized block is at %v", finalizedHeight)
 
 	// check if the fast sync works by checking if the gap is not more than 1
-	currentHeaderRes, err := tm.BBNConsumerClient.QueryBestBlock()
-	currentHeight := currentHeaderRes.Height
+	currentHeight, err := tm.BBNConsumerClient.QueryLatestBlockHeight()
 	t.Logf("the current block is at %v", currentHeight)
 	require.NoError(t, err)
 	require.True(t, currentHeight < finalizedHeight+uint64(n))

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -369,18 +369,18 @@ func (tm *TestManager) WaitForFpShutDown(t *testing.T, pk *bbntypes.BIP340PubKey
 }
 
 func (tm *TestManager) StopAndRestartFpAfterNBlocks(t *testing.T, n int, fpIns *service.FinalityProviderInstance) {
-	blockBeforeStop, err := tm.BBNConsumerClient.QueryBestBlock()
+	blockBeforeStopHeight, err := tm.BBNConsumerClient.QueryLatestBlockHeight()
 	require.NoError(t, err)
 	err = fpIns.Stop()
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		headerAfterStop, err := tm.BBNConsumerClient.QueryBestBlock()
+		headerAfterStopHeight, err := tm.BBNConsumerClient.QueryLatestBlockHeight()
 		if err != nil {
 			return false
 		}
 
-		return headerAfterStop.Height >= uint64(n)+blockBeforeStop.Height
+		return headerAfterStopHeight >= uint64(n)+blockBeforeStopHeight
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 
 	t.Log("restarting the finality-provider instance")

--- a/testutil/mocks/clientcontroller.go
+++ b/testutil/mocks/clientcontroller.go
@@ -148,21 +148,6 @@ func (mr *MockConsumerControllerMockRecorder) QueryActivatedHeight() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryActivatedHeight", reflect.TypeOf((*MockConsumerController)(nil).QueryActivatedHeight))
 }
 
-// QueryBestBlock mocks base method.
-func (m *MockConsumerController) QueryBestBlock() (*types.BlockInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryBestBlock")
-	ret0, _ := ret[0].(*types.BlockInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// QueryBestBlock indicates an expected call of QueryBestBlock.
-func (mr *MockConsumerControllerMockRecorder) QueryBestBlock() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryBestBlock", reflect.TypeOf((*MockConsumerController)(nil).QueryBestBlock))
-}
-
 // QueryBlock mocks base method.
 func (m *MockConsumerController) QueryBlock(height uint64) (*types.BlockInfo, error) {
 	m.ctrl.T.Helper()
@@ -206,6 +191,21 @@ func (m *MockConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.Pu
 func (mr *MockConsumerControllerMockRecorder) QueryFinalityProviderVotingPower(fpPk, blockHeight interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFinalityProviderVotingPower", reflect.TypeOf((*MockConsumerController)(nil).QueryFinalityProviderVotingPower), fpPk, blockHeight)
+}
+
+// QueryLatestBlockHeight mocks base method.
+func (m *MockConsumerController) QueryLatestBlockHeight() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryLatestBlockHeight")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryLatestBlockHeight indicates an expected call of QueryLatestBlockHeight.
+func (mr *MockConsumerControllerMockRecorder) QueryLatestBlockHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLatestBlockHeight", reflect.TypeOf((*MockConsumerController)(nil).QueryLatestBlockHeight))
 }
 
 // QueryLatestFinalizedBlocks mocks base method.

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -30,13 +30,8 @@ func PrepareMockedConsumerController(t *testing.T, r *rand.Rand, startHeight, cu
 		mockConsumerController.EXPECT().QueryBlock(i).Return(resBlock, nil).AnyTimes()
 	}
 
-	currentBlockRes := &types.BlockInfo{
-		Height: currentHeight,
-		Hash:   GenRandomByteArray(r, 32),
-	}
-
 	mockConsumerController.EXPECT().Close().Return(nil).AnyTimes()
-	mockConsumerController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
+	mockConsumerController.EXPECT().QueryLatestBlockHeight().Return(currentHeight, nil).AnyTimes()
 	mockConsumerController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 
 	return mockConsumerController


### PR DESCRIPTION
## Summary
After analyzing all the call sites of `QueryBestBlock()`, I realized that none of the call sites needs to know the latest block's hash or whether it's finalized or not.

Plus, this function returns the latest consumer chain block, which is ofc not finalized. So the `finalized` field should always be `false`. So this function can cause confusion.

And to better reflect what this function does, I also rename to `QueryLatestBlockHeight`

## Test Plan
```
make mock-gen
make test
```