### PR TITLE
feat :  QueryActivatedHeight()

### DIFF
--- a/clientcontroller/evm_consumer.go
+++ b/clientcontroller/evm_consumer.go
@@ -75,19 +75,19 @@ func (ec *EVMConsumerController) QueryFinalityProviderVotingPower(fpPk *btcec.Pu
 
 	*/
 
-	latest_committed_l2_height, err := ec.queryLatestFinalizedNumber()
+	/*latest_committed_l2_height, err := ec.queryLatestFinalizedNumber()
 	if err != nil {
 		return 0, fmt.Errorf("can't get latest finalized block number:%s", err)
-	}
+	}*/
 
-	if blockHeight > latest_committed_l2_height {
-		//query the VP from the L1 oracle contract using "latest" as the block tag
-	} else {
-		/*1. query the L1 event `emit OutputProposed(_outputRoot, nextOutputIndex(), _l2BlockNumber, block.timestamp, block.number);`
-			to find the first event where the `_l2BlockNumber` >= blockHeight
-		     2. get the block.number from the event
-		     3. query the VP from the L1 oracle contract using `block.number` as the block tag	*/
-	}
+	/*if blockHeight > latest_committed_l2_height {
+	           query the VP from the L1 oracle contract using "latest" as the block tag
+		} else {
+			   /*1. query the L1 event `emit OutputProposed(_outputRoot, nextOutputIndex(), _l2BlockNumber, block.timestamp, block.number);`
+				to find the first event where the `_l2BlockNumber` >= blockHeight
+			     2. get the block.number from the event
+			     3. query the VP from the L1 oracle contract using `block.number` as the block tag
+		}*/
 
 	return 0, nil
 }

--- a/finality-provider/config/evm.go
+++ b/finality-provider/config/evm.go
@@ -10,24 +10,24 @@ const (
 )
 
 type EVMConfig struct {
-	RPCL1Addr          string `long:"rpcl1-address" description:"address of the L1 RPC server to connect to"`
-	RPCL2Addr          string `long:"rpcl2-address" description:"address of the L2 RPC server to connect to"`
-	L2OutputOracleAddr string `long:"l2outputoracle-address" description:"address of the L2OutputOracle smart contract"`
-	BSAddr             string `long:"bitcoinstacking-address" description:"address of the BitcoinStaking smart contract"`
+	L1RPCAddr        string `long:"rpcl1-address" description:"address of the L1 RPC server to connect to"`
+	ConsumerRPCAddr  string `long:"consumer-chain-address" description:"address of the consumer chain RPC server to connect to"`
+	EOTSVerifierAddr string `long:"EOTSVerifier-address" description:"address of the EOTSVerifier smart contract"`
+	FPOracleAddr     string `long:"finality-provider-address" description:"address of the finality provider smart contract"`
 }
 
 func DefaultEVMConfig() EVMConfig {
 	return EVMConfig{
-		RPCL2Addr: defaultEVMRPCAddr,
+		L1RPCAddr: defaultEVMRPCAddr,
 	}
 }
 
 func (cfg *EVMConfig) Validate() error {
-	if _, err := url.Parse(cfg.RPCL1Addr); err != nil {
-		return fmt.Errorf("rpcl1-addr is not correctly formatted: %w", err)
+	if _, err := url.Parse(cfg.L1RPCAddr); err != nil {
+		return fmt.Errorf("rpcl1-address is not correctly formatted: %w", err)
 	}
-	if _, err := url.Parse(cfg.RPCL2Addr); err != nil {
-		return fmt.Errorf("rpcl2-addr is not correctly formatted: %w", err)
+	if _, err := url.Parse(cfg.ConsumerRPCAddr); err != nil {
+		return fmt.Errorf("consumer-chain-address is not correctly formatted: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- implement `QueryActivatedHeight` 
- add `querynextBlockNumber`to compute the block number of the next L2 block that needs to be checkpointed.
- add `queryBestBlock`to find the first block where the `block.number` >= l1_activated_height in event `OutputProposed`
- add codes and notes for l1 oracle contract `VotingPowerUpdated` event parts in comments
- delete useless L2outputOracle parts
**- this pull request is not a completed request as functions are not fully implement, it can be used for discussion about the final designing for l1 oracle contract.**

## Next Steps:
- implement `QueryFinalityProviderVotingPower`

## Question:
- How do we get votingPower from L1 oracle contract by tag, there will be function like `getVotingPowerbyNumber()` or we also find information in event?
- As far as I understand, every time the votingPower is updated,  an event `VotingPowerUpdated` will emit, but we always only need the number when it is first set ? 
- For the activatedHeight, do we still need find the first block from EOTSVerifier bigger than FP oracle activated height ? 

## Test Plan
```
make mock-gen
make test
```